### PR TITLE
Fix sonarqube

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,8 +27,8 @@ pipeline {
             steps {
                 script {
                     withSonarQubeEnv('SonarQube') {
-                        docker.image("sonarsource/sonar-scanner-cli").inside {
-                            sh("sonar-scanner")
+                        docker.image('sonarsource/sonar-scanner-cli').inside {
+                            sh('sonar-scanner')
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,9 +25,11 @@ pipeline {
             //    branch 'main'
             //}
             steps {
-                withSonarQubeEnv('SonarQube') {
-                    docker.image("sonarsource/sonar-scanner-cli").inside {
-                        sh("sonar-scanner")
+                script {
+                    withSonarQubeEnv('SonarQube') {
+                        docker.image("sonarsource/sonar-scanner-cli").inside {
+                            sh("sonar-scanner")
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,9 +42,10 @@ pipeline {
                 script {
                     def img = docker.build("zouipo/yumsday:${env.TAG_NAME}", '--target runtime .')
                     docker.withRegistry('', 'docker-zouipo') {
-                        sh("echo ${img.id}")
-                        //img.push()
-                        //img.push('latest')
+                        img.push()
+                        if (env.TAG_NAME ==~ /^\d+\.\d+\.\d+$/) {
+                            img.push('latest')
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,3 @@
-def img
-
 pipeline {
     agent any
 
@@ -9,27 +7,28 @@ pipeline {
 
     stages {
         stage('Run Tests') {
-            when {
-                not {
-                    buildingTag()
-                }
-            }
+            //when {
+            //    not {
+            //        buildingTag()
+            //    }
+            //}
             steps {
                 script {
-                    img = docker.build('zouipo/yumsday:base', '--target base .')
-                    img.inside {
+                    docker.build('zouipo/yumsday:base', '--target base .').inside {
                         sh('make test-cicd')
                     }
                 }
             }
         }
         stage('SonarQube Analysis') {
-            when {
-                branch 'main'
-            }
+            //when {
+            //    branch 'main'
+            //}
             steps {
                 withSonarQubeEnv('SonarQube') {
-                    sh("${tool('SonarQube Scanner')}/bin/sonar-scanner")
+                    docker.image("sonarsource/sonar-scanner-cli").inside {
+                        sh("sonar-scanner")
+                    }
                 }
             }
         }
@@ -39,10 +38,11 @@ pipeline {
             }
             steps {
                 script {
-                    img = docker.build("zouipo/yumsday:${env.TAG_NAME}", '--target runtime .')
+                    def img = docker.build("zouipo/yumsday:${env.TAG_NAME}", '--target runtime .')
                     docker.withRegistry('', 'docker-zouipo') {
-                        img.push()
-                        img.push('latest')
+                        sh("echo ${img.id}")
+                        //img.push()
+                        //img.push('latest')
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,9 +35,9 @@ pipeline {
             }
         }
         stage('Release Docker Image') {
-            when {
-                buildingTag()
-            }
+            //when {
+            //    buildingTag()
+            //}
             steps {
                 script {
                     def img = docker.build("zouipo/yumsday:${env.TAG_NAME}", '--target runtime .')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,11 +7,11 @@ pipeline {
 
     stages {
         stage('Run Tests') {
-            //when {
-            //    not {
-            //        buildingTag()
-            //    }
-            //}
+            when {
+                not {
+                    buildingTag()
+                }
+            }
             steps {
                 script {
                     docker.build('zouipo/yumsday:base', '--target base .').inside {
@@ -21,9 +21,9 @@ pipeline {
             }
         }
         stage('SonarQube Analysis') {
-            //when {
-            //    branch 'main'
-            //}
+            when {
+                branch 'main'
+            }
             steps {
                 script {
                     withSonarQubeEnv('SonarQube') {
@@ -35,9 +35,9 @@ pipeline {
             }
         }
         stage('Release Docker Image') {
-            //when {
-            //    buildingTag()
-            //}
+            when {
+                buildingTag()
+            }
             steps {
                 script {
                     def img = docker.build("zouipo/yumsday:${env.TAG_NAME}", '--target runtime .')


### PR DESCRIPTION
Fix sonarqube which wasn't able to analyze js code.
Only push docker image with the "latest" tag when building a git tag matching the semantic versioning pattern we use: `x.x.x`.
Other minor simplifications in the jenkinsfile.